### PR TITLE
fix: add health profile wizard navigation button on empty profile page

### DIFF
--- a/proj2/frontend/src/pages/HealthProfile.tsx
+++ b/proj2/frontend/src/pages/HealthProfile.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router';
-import { User, AlertCircle, ArrowLeft } from 'lucide-react';
+import { User, AlertCircle, ArrowLeft, ArrowRight } from 'lucide-react';
 import { healthProfileApi, getAuthToken, type HealthProfile, type Allergen } from '@/lib/api';
 import { BasicInfoCard, AllergiesCard, DietaryPreferencesCard } from '@/components/health-profile';
 import { DashboardNavbar } from '@/components/DashboardNavbar';
@@ -110,6 +110,14 @@ function HealthProfilePage() {
             <p className="mb-8 text-center text-gray-600">
               Create your health profile to get personalized dietary recommendations
             </p>
+            <Button
+              size="lg"
+              onClick={() => navigate('/health-profile-wizard')}
+              className="gap-2 bg-emerald-600 hover:bg-emerald-700"
+            >
+              Create Health Profile
+              <ArrowRight className="size-4" />
+            </Button>
           </div>
         )}
 


### PR DESCRIPTION
Closes #167

## Description of Changes

This PR fixes the bug where users without a health profile are unable to access the health profile creation wizard from the UI.

### Problem
- When users click the Health Profile card on the Dashboard, they are redirected to `/health-profile`
- The page shows 'No health profile yet' message but provides no way to create a profile
- Users are stuck with no clear path forward

### Solution
Added a 'Create Health Profile' button on the `/health-profile` page that:
- Appears only when no health profile exists
- Navigates to `/health-profile-wizard` when clicked
- Uses consistent styling with the rest of the application (emerald-600 background)
- Includes an arrow icon for visual clarity

### Changes Made
- **File**: `proj2/frontend/src/pages/HealthProfile.tsx`
  - Added `ArrowRight` icon import from lucide-react
  - Added `Button` component with click handler to navigate to wizard
  - Button appears in the 'No Profile State' section

### Visual Impact
**Before**: Empty state with just text, no action possible
**After**: Call-to-action button that guides users to create their profile

### Testing
- ✅ Button appears when no health profile exists
- ✅ Clicking button navigates to `/health-profile-wizard`
- ✅ Wizard flow works as expected
- ✅ No regression for users with existing profiles

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] The fix addresses the root cause of issue #167
- [x] UI/UX improvement provides clear user guidance
- [x] No breaking changes introduced